### PR TITLE
feat: add explore command and location area encounters

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -6,7 +6,7 @@ import "github.com/zombiedevgroup/pokedexcli/internal/pokeapi"
 type Command struct {
 	Name     string
 	Usage    string
-	Callback func() error
+	Callback func([]string) error
 }
 
 // Shared state for the commands package

--- a/internal/commands/explore.go
+++ b/internal/commands/explore.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"fmt"
+)
+
+func CommandExplore(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: explore <location>")
+	}
+
+	locationName := args[0]
+	encounters, err := PokeClient.GetEncounters(locationName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Exploring %s...\n", locationName)
+	fmt.Printf("Found Pokemon:\n")
+	for _, encounter := range encounters {
+		fmt.Printf("- %s\n", encounter.Pokemon.Name)
+	}
+
+	return nil
+}

--- a/internal/pokeapi/client.go
+++ b/internal/pokeapi/client.go
@@ -57,3 +57,45 @@ func (c *Client) GetLocationArea(id int) (LocationArea, error) {
 
 	return location, nil
 }
+
+func (c *Client) GetEncounters(name string) ([]PokemonEncounter, error) {
+	url := fmt.Sprintf("%s/location-area/%s", c.baseURL, name)
+
+	// Check cache first
+	if cached, ok := c.cache.Get(url); ok {
+		var locationArea struct {
+			PokemonEncounters []PokemonEncounter `json:"pokemon_encounters"`
+		}
+		err := json.Unmarshal(cached, &locationArea)
+		if err != nil {
+			return []PokemonEncounter{}, err
+		}
+		return locationArea.PokemonEncounters, nil
+	}
+
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		return []PokemonEncounter{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		return []PokemonEncounter{}, fmt.Errorf("location area %s not found", name)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return []PokemonEncounter{}, err
+	}
+
+	var locationArea struct {
+		PokemonEncounters []PokemonEncounter `json:"pokemon_encounters"`
+	}
+	err = json.Unmarshal(body, &locationArea)
+	if err != nil {
+		return []PokemonEncounter{}, err
+	}
+
+	c.cache.Add(url, body)
+	return locationArea.PokemonEncounters, nil
+}

--- a/internal/pokeapi/types.go
+++ b/internal/pokeapi/types.go
@@ -18,3 +18,11 @@ type LocationArea struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
+
+// Encounter represents an encounter in a location area
+type PokemonEncounter struct {
+	Pokemon struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"pokemon"`
+}

--- a/main.go
+++ b/main.go
@@ -21,26 +21,32 @@ func main() {
 		"exit": {
 			Name:     "exit",
 			Usage:    "exit: Exit the Pokedex",
-			Callback: commands.CommandExit,
+			Callback: func(args []string) error { return commands.CommandExit() },
 		},
 	}
 
 	cliCommands["help"] = commands.Command{
 		Name:     "help",
 		Usage:    "help: Display a help message",
-		Callback: func() error { return commands.CommandHelp(cliCommands) },
+		Callback: func(args []string) error { return commands.CommandHelp(cliCommands) },
 	}
 
 	cliCommands["map"] = commands.Command{
 		Name:     "map",
 		Usage:    "map: Display next page of locations",
-		Callback: commands.CommandMap,
+		Callback: func(args []string) error { return commands.CommandMap() },
 	}
 
 	cliCommands["mapb"] = commands.Command{
 		Name:     "mapb",
 		Usage:    "mapb: Display previous page of locations",
-		Callback: commands.CommandMapb,
+		Callback: func(args []string) error { return commands.CommandMapb() },
+	}
+
+	cliCommands["explore"] = commands.Command{
+		Name:     "explore",
+		Usage:    "explore <location>: Explore a location",
+		Callback: commands.CommandExplore,
 	}
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -54,8 +60,10 @@ func main() {
 		}
 
 		commandName := words[0]
+		args := words[1:]
+		
 		if command, ok := cliCommands[commandName]; ok {
-			if err := command.Callback(); err != nil {
+			if err := command.Callback(args); err != nil {
 				fmt.Println(err)
 			}
 		} else {


### PR DESCRIPTION
This commit adds several features and improvements:

- Add explore command to view Pokemon in a location area
- Add GetEncounters method to pokeapi client with 404 handling
- Add PokemonEncounter type for encounter data
- Update Command struct to support command arguments
- Refactor main.go to pass command arguments to callbacks
- Update existing command callbacks to match new signature

The explore command allows users to see what Pokemon can be found in a specific location area, with proper error handling for non-existent locations.