### PR TITLE
feat: add inspect command for caught pokemon

### DIFF
--- a/internal/commands/inspect.go
+++ b/internal/commands/inspect.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/zombiedevgroup/pokedexcli/internal/pokedex"
+)
+
+func CommandInspect(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: inspect <pokemon>")
+	}
+	pokemon, isFound := pokedex.FindPokemon(args[0])
+	if isFound == false {
+		return fmt.Errorf("you have not caught that pokemon")
+	}
+
+	fmt.Printf("Name: %s\n", pokemon.Name)
+	fmt.Printf("Height: %d\n", pokemon.Height)
+	fmt.Printf("Weight: %d\n", pokemon.Weight)
+	fmt.Printf("Stats:\n")
+
+	for _, stat := range pokemon.Stats {
+		fmt.Printf("\t- %v: %v\n", stat.Stat.Name, stat.BaseStat)
+	}
+
+	fmt.Printf("Types:\n")
+	for _, typeInfo := range pokemon.Types {
+		fmt.Printf("\t- %s\n", typeInfo.Type.Name)
+	}
+
+	return nil
+}

--- a/internal/pokeapi/types.go
+++ b/internal/pokeapi/types.go
@@ -28,7 +28,273 @@ type PokemonEncounter struct {
 }
 
 type Pokemon struct {
+	ID             int    `json:"id"`
 	Name           string `json:"name"`
-	URL            string `json:"url"`
 	BaseExperience int    `json:"base_experience"`
+	Height         int    `json:"height"`
+	IsDefault      bool   `json:"is_default"`
+	Order          int    `json:"order"`
+	Weight         int    `json:"weight"`
+	Abilities      []struct {
+		IsHidden bool `json:"is_hidden"`
+		Slot     int  `json:"slot"`
+		Ability  struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"ability"`
+	} `json:"abilities"`
+	Forms []struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"forms"`
+	GameIndices []struct {
+		GameIndex int `json:"game_index"`
+		Version   struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"version"`
+	} `json:"game_indices"`
+	HeldItems []struct {
+		Item struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"item"`
+		VersionDetails []struct {
+			Rarity  int `json:"rarity"`
+			Version struct {
+				Name string `json:"name"`
+				URL  string `json:"url"`
+			} `json:"version"`
+		} `json:"version_details"`
+	} `json:"held_items"`
+	LocationAreaEncounters string `json:"location_area_encounters"`
+	Moves                  []struct {
+		Move struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"move"`
+		VersionGroupDetails []struct {
+			LevelLearnedAt int `json:"level_learned_at"`
+			VersionGroup   struct {
+				Name string `json:"name"`
+				URL  string `json:"url"`
+			} `json:"version_group"`
+			MoveLearnMethod struct {
+				Name string `json:"name"`
+				URL  string `json:"url"`
+			} `json:"move_learn_method"`
+		} `json:"version_group_details"`
+	} `json:"moves"`
+	Species struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+	} `json:"species"`
+	Sprites struct {
+		BackDefault      string `json:"back_default"`
+		BackFemale       any    `json:"back_female"`
+		BackShiny        string `json:"back_shiny"`
+		BackShinyFemale  any    `json:"back_shiny_female"`
+		FrontDefault     string `json:"front_default"`
+		FrontFemale      any    `json:"front_female"`
+		FrontShiny       string `json:"front_shiny"`
+		FrontShinyFemale any    `json:"front_shiny_female"`
+		Other            struct {
+			DreamWorld struct {
+				FrontDefault string `json:"front_default"`
+				FrontFemale  any    `json:"front_female"`
+			} `json:"dream_world"`
+			Home struct {
+				FrontDefault     string `json:"front_default"`
+				FrontFemale      any    `json:"front_female"`
+				FrontShiny       string `json:"front_shiny"`
+				FrontShinyFemale any    `json:"front_shiny_female"`
+			} `json:"home"`
+			OfficialArtwork struct {
+				FrontDefault string `json:"front_default"`
+				FrontShiny   string `json:"front_shiny"`
+			} `json:"official-artwork"`
+			Showdown struct {
+				BackDefault      string `json:"back_default"`
+				BackFemale       any    `json:"back_female"`
+				BackShiny        string `json:"back_shiny"`
+				BackShinyFemale  any    `json:"back_shiny_female"`
+				FrontDefault     string `json:"front_default"`
+				FrontFemale      any    `json:"front_female"`
+				FrontShiny       string `json:"front_shiny"`
+				FrontShinyFemale any    `json:"front_shiny_female"`
+			} `json:"showdown"`
+		} `json:"other"`
+		Versions struct {
+			GenerationI struct {
+				RedBlue struct {
+					BackDefault  string `json:"back_default"`
+					BackGray     string `json:"back_gray"`
+					FrontDefault string `json:"front_default"`
+					FrontGray    string `json:"front_gray"`
+				} `json:"red-blue"`
+				Yellow struct {
+					BackDefault  string `json:"back_default"`
+					BackGray     string `json:"back_gray"`
+					FrontDefault string `json:"front_default"`
+					FrontGray    string `json:"front_gray"`
+				} `json:"yellow"`
+			} `json:"generation-i"`
+			GenerationIi struct {
+				Crystal struct {
+					BackDefault  string `json:"back_default"`
+					BackShiny    string `json:"back_shiny"`
+					FrontDefault string `json:"front_default"`
+					FrontShiny   string `json:"front_shiny"`
+				} `json:"crystal"`
+				Gold struct {
+					BackDefault  string `json:"back_default"`
+					BackShiny    string `json:"back_shiny"`
+					FrontDefault string `json:"front_default"`
+					FrontShiny   string `json:"front_shiny"`
+				} `json:"gold"`
+				Silver struct {
+					BackDefault  string `json:"back_default"`
+					BackShiny    string `json:"back_shiny"`
+					FrontDefault string `json:"front_default"`
+					FrontShiny   string `json:"front_shiny"`
+				} `json:"silver"`
+			} `json:"generation-ii"`
+			GenerationIii struct {
+				Emerald struct {
+					FrontDefault string `json:"front_default"`
+					FrontShiny   string `json:"front_shiny"`
+				} `json:"emerald"`
+				FireredLeafgreen struct {
+					BackDefault  string `json:"back_default"`
+					BackShiny    string `json:"back_shiny"`
+					FrontDefault string `json:"front_default"`
+					FrontShiny   string `json:"front_shiny"`
+				} `json:"firered-leafgreen"`
+				RubySapphire struct {
+					BackDefault  string `json:"back_default"`
+					BackShiny    string `json:"back_shiny"`
+					FrontDefault string `json:"front_default"`
+					FrontShiny   string `json:"front_shiny"`
+				} `json:"ruby-sapphire"`
+			} `json:"generation-iii"`
+			GenerationIv struct {
+				DiamondPearl struct {
+					BackDefault      string `json:"back_default"`
+					BackFemale       any    `json:"back_female"`
+					BackShiny        string `json:"back_shiny"`
+					BackShinyFemale  any    `json:"back_shiny_female"`
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"diamond-pearl"`
+				HeartgoldSoulsilver struct {
+					BackDefault      string `json:"back_default"`
+					BackFemale       any    `json:"back_female"`
+					BackShiny        string `json:"back_shiny"`
+					BackShinyFemale  any    `json:"back_shiny_female"`
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"heartgold-soulsilver"`
+				Platinum struct {
+					BackDefault      string `json:"back_default"`
+					BackFemale       any    `json:"back_female"`
+					BackShiny        string `json:"back_shiny"`
+					BackShinyFemale  any    `json:"back_shiny_female"`
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"platinum"`
+			} `json:"generation-iv"`
+			GenerationV struct {
+				BlackWhite struct {
+					Animated struct {
+						BackDefault      string `json:"back_default"`
+						BackFemale       any    `json:"back_female"`
+						BackShiny        string `json:"back_shiny"`
+						BackShinyFemale  any    `json:"back_shiny_female"`
+						FrontDefault     string `json:"front_default"`
+						FrontFemale      any    `json:"front_female"`
+						FrontShiny       string `json:"front_shiny"`
+						FrontShinyFemale any    `json:"front_shiny_female"`
+					} `json:"animated"`
+					BackDefault      string `json:"back_default"`
+					BackFemale       any    `json:"back_female"`
+					BackShiny        string `json:"back_shiny"`
+					BackShinyFemale  any    `json:"back_shiny_female"`
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"black-white"`
+			} `json:"generation-v"`
+			GenerationVi struct {
+				OmegarubyAlphasapphire struct {
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"omegaruby-alphasapphire"`
+				XY struct {
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"x-y"`
+			} `json:"generation-vi"`
+			GenerationVii struct {
+				Icons struct {
+					FrontDefault string `json:"front_default"`
+					FrontFemale  any    `json:"front_female"`
+				} `json:"icons"`
+				UltraSunUltraMoon struct {
+					FrontDefault     string `json:"front_default"`
+					FrontFemale      any    `json:"front_female"`
+					FrontShiny       string `json:"front_shiny"`
+					FrontShinyFemale any    `json:"front_shiny_female"`
+				} `json:"ultra-sun-ultra-moon"`
+			} `json:"generation-vii"`
+			GenerationViii struct {
+				Icons struct {
+					FrontDefault string `json:"front_default"`
+					FrontFemale  any    `json:"front_female"`
+				} `json:"icons"`
+			} `json:"generation-viii"`
+		} `json:"versions"`
+	} `json:"sprites"`
+	Cries struct {
+		Latest string `json:"latest"`
+		Legacy string `json:"legacy"`
+	} `json:"cries"`
+	Stats []struct {
+		BaseStat int `json:"base_stat"`
+		Effort   int `json:"effort"`
+		Stat     struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"stat"`
+	} `json:"stats"`
+	Types []struct {
+		Slot int `json:"slot"`
+		Type struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"type"`
+	} `json:"types"`
+	PastTypes []struct {
+		Generation struct {
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"generation"`
+		Types []struct {
+			Slot int `json:"slot"`
+			Type struct {
+				Name string `json:"name"`
+				URL  string `json:"url"`
+			} `json:"type"`
+		} `json:"types"`
+	} `json:"past_types"`
 }

--- a/internal/pokedex/pokedex.go
+++ b/internal/pokedex/pokedex.go
@@ -12,3 +12,8 @@ func AddPokemon(pokemonName string, pokemon pokeapi.Pokemon) {
 	Pokedex[pokemonName] = pokemon
 	// fmt.Printf("Added %s to Pokedex\n", pokemonName)
 }
+
+func FindPokemon(pokemonName string) (pokeapi.Pokemon, bool) {
+	pokemon, ok := Pokedex[pokemonName]
+	return pokemon, ok
+}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,12 @@ func main() {
 		Callback: commands.CommandCatch,
 	}
 
+	cliCommands["inspect"] = commands.Command{
+		Name:     "inspect",
+		Usage:    "inspect <pokemon>: Inspect a pokemon",
+		Callback: commands.CommandInspect,
+	}
+
 	scanner := bufio.NewScanner(os.Stdin)
 	for {
 		fmt.Print("Pokedex > ")


### PR DESCRIPTION
Added the ability to inspect caught pokemon with detailed information including:
- Basic stats (height, weight)
- Base stats
- Types

Changes:
- Added new inspect.go command implementation
- Extended Pokemon type structure in types.go
- Added FindPokemon helper in pokedex package
- Registered inspect command in main.go
